### PR TITLE
Moves CheckReadPermissions inside the router

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useEffect } from 'react';
 import { matchPath, Route, RouteProps, Switch, useHistory } from 'react-router';
 
+import { CheckReadPermissions } from './components/CheckReadPermissions';
 import { RedirectToDefaultBundle } from './components/RedirectToDefaultBundle';
 import { ErrorPage } from './pages/Error/Page';
 import { ConnectedIntegrationsListPage } from './pages/Integrations/List/Page';
@@ -45,9 +46,14 @@ const pathRoutes: Path[] = [
 type InsightsRouteProps = RouteProps;
 
 const InsightsRoute: React.FunctionComponent<InsightsRouteProps> = (props: InsightsRouteProps) => {
+    const { component, ...restProps } = props;
     return (
         <ErrorPage>
-            <Route { ...props } />
+            <Route { ...restProps }>
+                <CheckReadPermissions>
+                    { props.component }
+                </CheckReadPermissions>
+            </Route>
         </ErrorPage>
     );
 };

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,7 +8,6 @@ import format from 'date-fns/format';
 import * as React from 'react';
 import { style } from 'typestyle';
 
-import { CheckReadPermissions } from '../components/CheckReadPermissions';
 import { Routes } from '../Routes';
 import { staging } from '../types/Environments';
 import { ServerStatus } from '../types/Server';
@@ -70,21 +69,19 @@ const App: React.ComponentType = () => {
             isOrgAdmin: !!isOrgAdmin
         } }>
             <>
-                <CheckReadPermissions>
-                    <NotificationsPortal />
-                    <InsightsEnvDetector insights={ insights } onEnvironment={ staging }>
-                        <RenderIfTrue>
-                            <Switch
-                                className={ switchClassname }
-                                isChecked={ usingExperimental }
-                                onChange={ toggleExperimental }
-                                labelOff="Enable experimental features"
-                                label="Disable experimental features"
-                            />
-                        </RenderIfTrue>
-                    </InsightsEnvDetector>
-                    <Routes />
-                </CheckReadPermissions>
+                <NotificationsPortal />
+                <InsightsEnvDetector insights={ insights } onEnvironment={ staging }>
+                    <RenderIfTrue>
+                        <Switch
+                            className={ switchClassname }
+                            isChecked={ usingExperimental }
+                            onChange={ toggleExperimental }
+                            labelOff="Enable experimental features"
+                            label="Disable experimental features"
+                        />
+                    </RenderIfTrue>
+                </InsightsEnvDetector>
+                <Routes />
             </>
 
         </AppContext.Provider>

--- a/src/components/CheckReadPermissions.tsx
+++ b/src/components/CheckReadPermissions.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { useApp } from '../app/useApp';
 import Config from '../config/Config';
@@ -7,6 +8,7 @@ import { NotAuthorizedPage } from './NotAuthorized';
 
 export const CheckReadPermissions: React.FunctionComponent = (props) => {
     const { rbac } = useApp();
+    const location = useLocation();
 
     const hasReadPermissions = React.useMemo(() => {
         const appId = getSubApp(location.pathname);
@@ -18,11 +20,10 @@ export const CheckReadPermissions: React.FunctionComponent = (props) => {
         }
 
         return false;
-    }, [ rbac ]);
-
+    }, [ rbac, location ]);
     return (
         <>
-            { !hasReadPermissions ? <NotAuthorizedPage /> : { props } }
+            { !hasReadPermissions ? <NotAuthorizedPage /> : props.children }
         </>
     );
 };


### PR DESCRIPTION
 - Also fixes an issue with the location

Moving the CheckReadPermissions inside the router allows it fetch the bundle (if it exists).

Currently this component it's in charge of all the global permission checking to determine if we can access. We could to provide a per-route if needed.