### PR TITLE
fix(RHCLOUD-48491): Show unauthorized state for users without read permissions

### DIFF
--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -32,6 +32,7 @@ import { useIntegrationFilter } from './useIntegrationFilter';
 import { useIntegrationRows } from './useIntegrationRows';
 import { useFlag } from '@unleash/proxy-client-react';
 import DopeBox from '../../../components/Integrations/DopeBox';
+import { UnauthorizedState } from './UnauthorizedState';
 import { DataViewIntegrationsTable } from '../../../components/Integrations/IntegrationsTable';
 import { DataViewEventsProvider } from '@patternfly/react-data-view/dist/dynamic/DataViewEventsContext';
 import { Drawer, DrawerContent, DrawerContentBody } from '@patternfly/react-core';
@@ -71,7 +72,7 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
   const [focusedIntegration, setFocusedIntegration] = useState<IntegrationRow>();
   const drawerRef = React.useRef<HTMLDivElement>(null);
   const {
-    rbac: { canWriteIntegrationsEndpoints },
+    rbac: { canWriteIntegrationsEndpoints, canReadIntegrationsEndpoints },
   } = useContext(AppContext);
 
   const { addDangerNotification } = useNotification();
@@ -260,6 +261,11 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
     integrations.count < 1 &&
     !integrationsQuery.loading &&
     Object.values(integrationFilter.filters).every((filter) => !filter);
+
+  // If user doesn't have read permissions, show unauthorized state
+  if (!canReadIntegrationsEndpoints) {
+    return <UnauthorizedState />;
+  }
 
   return (
     <>

--- a/src/pages/Integrations/List/UnauthorizedState.tsx
+++ b/src/pages/Integrations/List/UnauthorizedState.tsx
@@ -1,0 +1,81 @@
+import {
+  Alert,
+  AlertActionLink,
+  Card,
+  CardBody,
+  Content,
+  ContentVariants,
+  EmptyState,
+  EmptyStateBody,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { LockIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { useIntl } from 'react-intl';
+
+export const UnauthorizedState: React.FunctionComponent = () => {
+  const intl = useIntl();
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Alert
+          customIcon={<LockIcon />}
+          variant="info"
+          isInline
+          isExpandable
+          title={intl.formatMessage({
+            id: 'integrations.unauthorizedState.alertTitle',
+            defaultMessage: 'Need to create an integration?',
+          })}
+          actionLinks={
+            <AlertActionLink
+              component="a"
+              href="https://access.redhat.com/articles/6957948"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {intl.formatMessage({
+                id: 'integrations.unauthorizedState.alertLink',
+                defaultMessage: 'Learn about requesting access via the Virtual Assistant',
+              })}
+            </AlertActionLink>
+          }
+        >
+          <Content>
+            <Content component={ContentVariants.p}>
+              {intl.formatMessage({
+                id: 'integrations.unauthorizedState.alertParagraph',
+                defaultMessage:
+                  'You do not have the permissions for integration management. Contact your organization admin if you need these permissions updated.',
+              })}
+            </Content>
+          </Content>
+        </Alert>
+      </StackItem>
+      <StackItem>
+        <Card isPlain>
+          <CardBody className="pf-v5-u-text-align-center">
+            <EmptyState
+              headingLevel={ContentVariants.h2}
+              icon={LockIcon}
+              titleText={intl.formatMessage({
+                id: 'integrations.unauthorizedState.heading',
+                defaultMessage: 'No integrations available',
+              })}
+            >
+              <EmptyStateBody>
+                {intl.formatMessage({
+                  id: 'integrations.unauthorizedState.description',
+                  defaultMessage:
+                    'You need read permissions to view integrations. Contact your organization administrator to request access.',
+                })}
+              </EmptyStateBody>
+            </EmptyState>
+          </CardBody>
+        </Card>
+      </StackItem>
+    </Stack>
+  );
+};


### PR DESCRIPTION
## Summary
Fixes RHCLOUD-48491 - Non-org admin users without integrations read permissions were seeing infinite loading spinners on the Communications, Reporting, and Webhooks tabs instead of a proper empty state.

## Problem
For non-org admin users without `integrations:endpoints:read` permissions:
- The `IntegrationsList` component only checked `canWriteIntegrationsEndpoints`
- It did not check `canReadIntegrationsEndpoints` before rendering
- The integrations API query would run and fail/hang for unauthorized users
- Users would see infinite spinners instead of an informative empty state

## Solution
1. Added `canReadIntegrationsEndpoints` permission check to `List.tsx`
2. Created new `UnauthorizedState` component that displays:
   - Informative alert explaining permission requirements
   - Link to request access via Virtual Assistant
   - Clear messaging to contact organization administrator
   - Lock icon and empty state pattern matching other unauthorized views
3. Show `UnauthorizedState` when user lacks read permissions, preventing the API query from running

## Testing
- [ ] Verify non-org admin users without read permissions see UnauthorizedState
- [ ] Verify non-org admin users with read permissions see normal integrations list
- [ ] Verify org admins see full functionality
- [ ] Test on Communications, Reporting & automation, and Webhooks tabs

## Files Changed
- `src/pages/Integrations/List/List.tsx` - Added permission check and UnauthorizedState rendering
- `src/pages/Integrations/List/UnauthorizedState.tsx` - New component for unauthorized users

## Related
- Related to sources-ui handling of integration tabs
- Ensures parity with Cloud and Red Hat tabs empty state behavior